### PR TITLE
added ocio config path to upython

### DIFF
--- a/config/upython.json
+++ b/config/upython.json
@@ -48,6 +48,9 @@
           "LD_LIBRARY_PATH": [
             "$ULIBS_ROOT/opencolorio/$UVER_OPENCOLORIO_VERSION/$UCORE_OS/lib"
           ]
+        },
+        "override": {
+          "OCIO": "$ULIBS_ROOT/opencolorio/configs/nuke-default/config.ocio"
         }
       }
     },


### PR DESCRIPTION
Adds the location for the default configuration used by open color io in upython. For now it's using a nuke configuration to make sure we get the same colors as the OCIO inside nuke, however we probably should move to ACES at some point.