### PR TITLE
ocio config

### DIFF
--- a/config/upython.json
+++ b/config/upython.json
@@ -48,9 +48,6 @@
           "LD_LIBRARY_PATH": [
             "$( locres libs/opencolorio/$UVER_OPENCOLORIO_VERSION )/$UCORE_OS/lib"
           ]
-        },
-        "override": {
-          "OCIO": "$( locres libs/opencolorio/configs )/nuke-default/config.ocio"
         }
       }
     },


### PR DESCRIPTION
This is no longer necessary, since now we can specify the OCIO config via an option in the tasks that use OCIO.

- Removed explicitly ocio config passed as environment variable in upython